### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "open62541"
+description := "An open source and free implementation of OPC UA (OPC Unified Architecture)."
+gitrepo     := "https://github.com/open62541/open62541.git"
+homepage    := "https://github.com/open62541/open62541/"
+license     := "MPL-2.0"
+version     := 9f1cbfa sha256:7b660f20f37c8f109ed2a96307ce47a54772e392c42b9fd96e8a2cf2a1c674bd https://github.com/neonious/open62541/archive/9f1cbfa.tar.gz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

